### PR TITLE
bump: upgrade Rust toolchain to `nightly-2022-08-23`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2022-07-26"
+channel = "nightly-2022-08-23"


### PR DESCRIPTION
Related issue - https://github.com/scroll-tech/devops/issues/14