### PR TITLE
fix: use docker image `rust-builder` with tag `nightly-2022-08-23` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build
 
-FROM scrolltech/rust-builder:nightly-2022-08-23 AS chef
+FROM scrolltech/rust-alpine-builder:nightly-2022-08-23 AS chef
 WORKDIR app
 
 FROM chef AS planner


### PR DESCRIPTION
Related `devops` issue - https://github.com/scroll-tech/devops/pull/18