### PR TITLE
fix: count rollup status `finalization_skipped` to last finalized index

### DIFF
--- a/src/open_api/responses/last_batch_indexes_response.rs
+++ b/src/open_api/responses/last_batch_indexes_response.rs
@@ -21,7 +21,9 @@ impl LastBatchIndexesResponse {
             all_index = all_index.max(index);
             match status.into() {
                 RollupStatus::Committed => committed_index = committed_index.max(index),
-                RollupStatus::Finalized => finalized_index = finalized_index.max(index),
+                RollupStatus::Finalized | RollupStatus::Skipped => {
+                    finalized_index = finalized_index.max(index)
+                }
                 _ => (),
             }
         }


### PR DESCRIPTION
Fixed to count batch index of rollup status `finalization_skipped` to both last committed and last finalized indexes (`committed_index = committed_index.max(finalized_index)` in below code). 