### PR TITLE
fix: update `search` API parameter to `keyword` to support both block number and block hash

### DIFF
--- a/src/db/queries/block_trace_query.rs
+++ b/src/db/queries/block_trace_query.rs
@@ -29,3 +29,14 @@ pub async fn get_batch_id_by_hash(db_pool: &DbPool, hash: &str) -> Result<Option
         .fetch_optional(db_pool)
         .await
 }
+
+pub async fn get_batch_id_by_number(db_pool: &DbPool, number: i64) -> Result<Option<String>> {
+    let stmt = format!(
+        "SELECT batch_id FROM {} where number = $1",
+        table_name::BLOCK_TRACE,
+    );
+    query_scalar::<_, String>(&stmt)
+        .bind(number)
+        .fetch_optional(db_pool)
+        .await
+}


### PR DESCRIPTION
### Summary

Fix `search` API parameter to `keyword`. If it is an integer, consider as `block_number`. Otherwise consider it as `block_hash` (starts with `0x`).