### PR TITLE
fix: make internal binding HTTP port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 Naturally, you will need the [Rust toolchain] installed.
 Besides that, [goose] is necessary for external database migrations in `database` dictionary of [scroll].
 
+## ENV
+
+- `BIND_PORT`: Internal binding HTTP port (`5001` as default).
+- `DB_URL`: The database URL used to connect.
+- `OPEN_API_ADDR`: Open API URL displayed on Web UI.
+
 ## Development
 
 - `make start`: Start a local `Postgres` docker-container, and `cargo run --bin rollup_explorer`. Then URL `http://0.0.0.0:5001` could be accessed in a Web browser.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     links:
       - db
     environment:
+      BIND_PORT: 8600
       OPEN_API_ADDR: "localhost:8600"
     ports:
-      - "8600:5001"
+      - "8600:8600"

--- a/src/open_api/mod.rs
+++ b/src/open_api/mod.rs
@@ -37,9 +37,8 @@ pub async fn run(cache: Arc<Cache>) -> Result<()> {
         .with(Cors::new().allow_origins_fn(|_| true))
         .data(state);
 
-    Server::new(TcpListener::bind("0.0.0.0:5001"))
-        .run(app)
-        .await?;
+    let bind_addr = format!("0.0.0.0:{}", settings.bind_port);
+    Server::new(TcpListener::bind(bind_addr)).run(app).await?;
 
     Ok(())
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -4,10 +4,14 @@ use serde::Deserialize;
 use std::env;
 use std::sync::OnceLock;
 
+const DEFAULT_BIND_PORT: &str = "5001";
+
 static SETTINGS: OnceLock<Settings> = OnceLock::new();
 
 #[derive(Debug, Deserialize)]
 pub struct Settings {
+    /// Internal HTTP bind port (5001 as default)
+    pub bind_port: String,
     /// As format of `postgres://USERNAME:PASSWORD@DB_HOST:DB_PORT/DATABASE`
     pub db_url: String,
     /// As format of `HTTP_HOST:HTTP_PORT`
@@ -18,8 +22,10 @@ pub struct Settings {
 
 impl Settings {
     pub fn init() -> Result<()> {
+        let bind_port = env::var("BIND_PORT").unwrap_or_else(|_| DEFAULT_BIND_PORT.into());
         let run_mode = env::var("RUN_MODE").unwrap_or_else(|_| "development".into());
         let config = Config::builder()
+            .set_default("bind_port", bind_port)?
             .set_default("run_mode", run_mode.clone())?
             .add_source(File::with_name("config/default"))
             .add_source(File::with_name(&format!("config/{}", run_mode)).required(false))


### PR DESCRIPTION
Asana task https://app.asana.com/0/1202293017617135/1203568298588390/f

After discussing with @Thegaram , we need to make make internal binding HTTP port configurable.