### PR TITLE
limit query parameter per_page from above

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Besides that, [goose] is necessary for external database migrations in `database
 - `BIND_PORT`: Internal binding HTTP port (`5001` as default).
 - `DB_URL`: The database URL used to connect.
 - `OPEN_API_ADDR`: Open API URL displayed on Web UI.
+- `MAX_PER_PAGE`: Max value of query parameter `per_page` (100 as default)
 
 ## Development
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,9 +1,8 @@
 // Expired seconds of cache data.
 pub const DEFAULT_CACHE_EXPIRED_SECS: u64 = 1;
 
-// Query parameter `page` starts from `1`, default `per_page` is 20, and max value is 100.
+// Query parameter `page` starts from `1`, default `per_page` is 20, and max value is 100 (configured in .env).
 pub const DEFAULT_PER_PAGE: u64 = 20;
-pub const MAX_PER_PAGE: u64 = 100;
 
 // Identify if batch is invalid.
 pub const INVALID_BATCH_INDEX: i64 = -1;

--- a/src/open_api/apis.rs
+++ b/src/open_api/apis.rs
@@ -65,8 +65,8 @@ impl Apis {
             || DEFAULT_PER_PAGE,
             |val| {
                 if val > 0 {
-                    if val > MAX_PER_PAGE {
-                        MAX_PER_PAGE
+                    if val > state.max_per_page {
+                        state.max_per_page
                     } else {
                         val
                     }

--- a/src/open_api/mod.rs
+++ b/src/open_api/mod.rs
@@ -16,12 +16,18 @@ mod responses;
 struct State {
     cache: Arc<Cache>,
     db_pool: DbPool,
+    max_per_page: u64,
 }
 
 pub async fn run(cache: Arc<Cache>) -> Result<()> {
     let settings = Settings::get();
     let db_pool = DbPool::connect(settings.db_url.as_str()).await?;
-    let state = State { cache, db_pool };
+    let max_per_page = settings.max_per_page;
+    let state = State {
+        cache,
+        db_pool,
+        max_per_page,
+    };
 
     let open_api_addr = &settings.open_api_addr;
     let svr = OpenApiService::new(apis::Apis, "Scroll Rollup Explorer", "2.0")

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -18,6 +18,8 @@ pub struct Settings {
     pub open_api_addr: String,
     /// `development` or `production`
     run_mode: String,
+    ///  Max value of query parameter `per_page` (100 as default)
+    pub max_per_page: u64,
 }
 
 impl Settings {
@@ -27,6 +29,7 @@ impl Settings {
         let config = Config::builder()
             .set_default("bind_port", bind_port)?
             .set_default("run_mode", run_mode.clone())?
+            .set_default("max_per_page", 100)?
             .add_source(File::with_name("config/default"))
             .add_source(File::with_name(&format!("config/{}", run_mode)).required(false))
             .add_source(Environment::default())


### PR DESCRIPTION
Currently we can open rollup explorer like this: https://scroll.io/prealpha/rollupscan?page=1&per_page=10000, `per_page` doesn't limited from above and this might make it vulnerable

