### PR TITLE
fix: set only `finalized` status for last finalized index

### DIFF
--- a/src/open_api/responses/last_batch_indexes_response.rs
+++ b/src/open_api/responses/last_batch_indexes_response.rs
@@ -20,10 +20,10 @@ impl LastBatchIndexesResponse {
         for (status, index) in status_indexes.into_iter() {
             all_index = all_index.max(index);
             match status.into() {
-                RollupStatus::Committed => committed_index = committed_index.max(index),
-                RollupStatus::Finalized | RollupStatus::Skipped => {
-                    finalized_index = finalized_index.max(index)
+                RollupStatus::Committed | RollupStatus::Skipped => {
+                    committed_index = committed_index.max(index)
                 }
+                RollupStatus::Finalized => finalized_index = finalized_index.max(index),
                 _ => (),
             }
         }


### PR DESCRIPTION
### Summary

1. Set only `finalized` status for last finalized index (for both `finalized` and `finalized_skipped` previously).
2. Set the maximum index of `committed`, `finalized_skipped` and `finalized` to last committed index.