### PR TITLE
fix: update dependency `serde`, `serde_derive` and `serde_json`

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -30,4 +30,6 @@ jobs:
           cargo install cargo-audit
           cargo audit \
             --deny warnings \
-            --ignore RUSTSEC-2020-0071
+            --ignore RUSTSEC-2020-0071 \
+            --ignore RUSTSEC-2023-0033 \
+            --ignore RUSTSEC-2023-0034

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,18 +1772,18 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1792,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",


### PR DESCRIPTION
### Summary

1. Update dependency `serde`, `serde_derive` and `serde_json`.
2. Update CI audit (to ignore some errors).

Related [dependabot](https://github.com/apps/dependabot) PR https://github.com/scroll-tech/rollup-explorer-backend/pull/119 and https://github.com/scroll-tech/rollup-explorer-backend/pull/120.

### Test

Test on local (with `http://localhost:5001`), the APIs could work.