### PR TITLE
fix: remove skip status in rollup status

### DIFF
--- a/src/open_api/objects/batch.rs
+++ b/src/open_api/objects/batch.rs
@@ -8,7 +8,6 @@ pub enum RollupStatus {
     Precommitted,
     Committed,
     Finalized,
-    Skipped,
     Unknown,
 }
 
@@ -18,7 +17,6 @@ impl fmt::Display for RollupStatus {
             Self::Precommitted => "precommitted",
             Self::Committed => "committed",
             Self::Finalized => "finalized",
-            Self::Skipped => "skipped",
             Self::Unknown => "unknown",
         };
         write!(f, "{s}")
@@ -31,7 +29,6 @@ impl From<RollupStatusType> for RollupStatus {
             1 | 2 => Self::Precommitted,
             3 | 4 => Self::Committed,
             5 => Self::Finalized,
-            6 => Self::Skipped,
             _ => Self::Unknown,
         }
     }

--- a/src/open_api/responses/last_batch_indexes_response.rs
+++ b/src/open_api/responses/last_batch_indexes_response.rs
@@ -18,9 +18,7 @@ impl LastBatchIndexesResponse {
         for (status, index) in status_indexes.into_iter() {
             all_index = all_index.max(index);
             match status.into() {
-                RollupStatus::Committed | RollupStatus::Skipped => {
-                    committed_index = committed_index.max(index)
-                }
+                RollupStatus::Committed => committed_index = committed_index.max(index),
                 RollupStatus::Finalized => finalized_index = finalized_index.max(index),
                 _ => (),
             }

--- a/third-parties/scroll/database/migrate/migrations/00004_chunk.sql
+++ b/third-parties/scroll/database/migrate/migrations/00004_chunk.sql
@@ -35,7 +35,7 @@ create table chunk
 );
 
 comment
-on column chunk.proving_status is 'undefined, unassigned, skipped, assigned, proved, verified, failed';
+on column chunk.proving_status is 'undefined, unassigned, assigned, proved, verified, failed';
 
 create unique index chunk_index_uindex
 on chunk (index);

--- a/third-parties/scroll/database/migrate/migrations/00005_batch.sql
+++ b/third-parties/scroll/database/migrate/migrations/00005_batch.sql
@@ -49,10 +49,10 @@ comment
 on column batch.chunk_proofs_status is 'undefined, pending, ready';
 
 comment
-on column batch.proving_status is 'undefined, unassigned, skipped, assigned, proved, verified, failed';
+on column batch.proving_status is 'undefined, unassigned, assigned, proved, verified, failed';
 
 comment
-on column batch.rollup_status is 'undefined, pending, committing, committed, finalizing, finalized, finalization_skipped, commit_failed, finalize_failed';
+on column batch.rollup_status is 'undefined, pending, committing, committed, finalizing, finalized, commit_failed, finalize_failed';
 
 -- +goose StatementEnd
 


### PR DESCRIPTION
The rollup explorer shows `committed` when the batch's rollup status is `commit failed`, because status in backend is outdated, and `commit failed` status collides with `skip`. After this fix, the rollup explorer would show `unknown` when `commit failed` instead of `committed`, which would make it much easier to expose the issue.