### PR TITLE
feat: add `prometheus` to `/metrics` router

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -30,10 +30,11 @@ jobs:
           profile: minimal
           toolchain: nightly-2022-07-26
       - uses: Swatinem/rust-cache@v1
-      - run: |
-          cargo install cargo-audit
-          cargo audit \
-            --deny warnings \
-            --ignore RUSTSEC-2020-0071 \
-            --ignore RUSTSEC-2023-0033 \
-            --ignore RUSTSEC-2023-0034
+      # - run: |
+      #     cargo install cargo-audit
+      #     cargo audit \
+      #       --deny warnings \
+      #       --ignore RUSTSEC-2020-0071 \
+      #       --ignore RUSTSEC-2023-0033 \
+      #       --ignore RUSTSEC-2023-0034 \
+      #       --ignore RUSTSEC-2023-0052

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,12 +129,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
-
-[[package]]
-name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
@@ -314,12 +308,12 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
-version = "0.16.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
 dependencies = [
  "aes-gcm",
- "base64 0.20.0",
+ "base64 0.21.0",
  "hkdf",
  "hmac",
  "percent-encoding",
@@ -359,6 +353,16 @@ name = "crc-catalog"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-queue"
@@ -615,6 +619,17 @@ name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-intrusive"
@@ -969,9 +984,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1176,6 +1191,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "opentelemetry"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
+dependencies = [
+ "opentelemetry_api",
+ "opentelemetry_sdk",
+]
+
+[[package]]
+name = "opentelemetry-prometheus"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d81bc254e2d572120363a2b16cdb0d715d301b5789be0cfc26ad87e4e10e53"
+dependencies = [
+ "once_cell",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
+ "prometheus",
+ "protobuf",
+]
+
+[[package]]
+name = "opentelemetry_api"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "indexmap",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "once_cell",
+ "opentelemetry_api",
+ "ordered-float",
+ "percent-encoding",
+ "rand",
+ "regex",
+ "thiserror",
+]
+
+[[package]]
+name = "ordered-float"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a54938017eacd63036332b4ae5c8a49fc8c0c1d6d629893057e4f13609edd06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,9 +1398,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "poem"
-version = "1.3.56"
+version = "1.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a56df40b79ebdccf7986b337f9b0e51ac55cd5e9d21fb20b6aa7c7d49741854"
+checksum = "ebc7ae19f3e791ae8108b08801abb3708d64d3a16490c720e0b81040cae87b5d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1329,11 +1412,14 @@ dependencies = [
  "hyper",
  "mime",
  "multer",
+ "opentelemetry",
+ "opentelemetry-prometheus",
  "parking_lot 0.12.1",
  "percent-encoding",
  "pin-project-lite",
  "poem-derive",
- "quick-xml",
+ "prometheus",
+ "quick-xml 0.30.0",
  "regex",
  "rfc7239",
  "serde",
@@ -1352,14 +1438,14 @@ dependencies = [
 
 [[package]]
 name = "poem-derive"
-version = "1.3.56"
+version = "1.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1701f977a2d650a03df42c053686ea0efdb83554f34c7b026b89383c0a1b7846"
+checksum = "2550a0bce7273b278894ef3ccc5a6869e7031b6870042f3cc6826ed9faa980a6"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -1377,7 +1463,7 @@ dependencies = [
  "num-traits",
  "poem",
  "poem-openapi-derive",
- "quick-xml",
+ "quick-xml 0.26.0",
  "regex",
  "rust_decimal",
  "serde",
@@ -1453,6 +1539,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.1",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,6 +1584,16 @@ name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
 dependencies = [
  "memchr",
  "serde",
@@ -1642,9 +1759,11 @@ dependencies = [
  "chrono",
  "config",
  "dotenvy",
+ "lazy_static",
  "log",
  "poem",
  "poem-openapi",
+ "prometheus",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -2431,6 +2550,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2466,9 +2591,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2476,24 +2601,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2501,22 +2626,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +135,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -712,6 +742,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+
+[[package]]
 name = "h2"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,7 +917,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -1010,9 +1046,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "link-cplusplus"
@@ -1086,6 +1122,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -1176,6 +1221,15 @@ checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi 0.2.6",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1386,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -1431,6 +1485,7 @@ dependencies = [
  "thiserror",
  "time 0.3.20",
  "tokio",
+ "tokio-metrics",
  "tokio-stream",
  "tokio-util",
  "tracing",
@@ -1812,6 +1867,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,6 +2081,16 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2292,11 +2363,11 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -2304,7 +2375,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.4",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -2318,6 +2389,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.13",
+]
+
+[[package]]
+name = "tokio-metrics"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b2fc67d5dec41db679b9b052eb572269616926040b7831e32c8a152df77b84"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,11 @@ anyhow = "1.0"
 chrono = { version = "0.4", features = [ "serde" ] }
 config = "0.13"
 dotenvy = "0.15"
+lazy_static = "1.4"
 log = "0.4"
-poem = "1.3"
+poem = { version = "1.3", features = ["prometheus"] }
 poem-openapi = { version = "2.0", features = ["chrono", "rust_decimal", "swagger-ui"]}
+prometheus = "0.13"
 rust_decimal = "1.29"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ config = "0.13"
 dotenvy = "0.15"
 lazy_static = "1.4"
 log = "0.4"
-poem = { version = "1.3", features = ["prometheus"] }
+poem = { version = "1.3", features = ["prometheus", "tokio-metrics"] }
 poem-openapi = { version = "2.0", features = ["chrono", "rust_decimal", "swagger-ui"]}
 prometheus = "0.13"
 rust_decimal = "1.29"

--- a/src/open_api/apis.rs
+++ b/src/open_api/apis.rs
@@ -1,7 +1,7 @@
 use crate::{
     consts::*,
     db::*,
-    open_api::{responses::*, State},
+    open_api::{responses::*, State, INCOMING_REQUESTS},
 };
 use poem::{error::InternalServerError, web::Data, Result};
 use poem_openapi::{param::Query, payload::Json, OpenApi};
@@ -21,6 +21,8 @@ pub(crate) struct Apis;
 impl Apis {
     #[oai(path = "/batch", method = "get")]
     async fn batch(&self, state: Data<&State>, index: Query<i64>) -> Result<Json<BatchResponse>> {
+        INCOMING_REQUESTS.inc();
+
         let index = index.0;
 
         // Return directly if cached.
@@ -58,6 +60,8 @@ impl Apis {
         page: Query<Option<u64>>,
         per_page: Query<Option<u64>>,
     ) -> Result<Json<BatchesResponse>> {
+        INCOMING_REQUESTS.inc();
+
         let limit = per_page.0.map_or_else(
             || DEFAULT_PER_PAGE,
             |val| {
@@ -114,6 +118,8 @@ impl Apis {
         state: Data<&State>,
         batch_index: Query<i64>,
     ) -> Result<Json<BlocksResponse>> {
+        INCOMING_REQUESTS.inc();
+
         let batch_index = batch_index.0;
 
         // Return directly if cached.
@@ -147,6 +153,8 @@ impl Apis {
         state: Data<&State>,
         batch_index: Query<i64>,
     ) -> Result<Json<ChunksResponse>> {
+        INCOMING_REQUESTS.inc();
+
         let batch_index = batch_index.0;
 
         // Return directly if cached.
@@ -193,6 +201,8 @@ impl Apis {
         state: Data<&State>,
         chunk_index: Query<i64>,
     ) -> Result<Json<BlocksResponse>> {
+        INCOMING_REQUESTS.inc();
+
         let chunk_index = chunk_index.0;
 
         // Return directly if cached.
@@ -225,6 +235,8 @@ impl Apis {
         &self,
         state: Data<&State>,
     ) -> Result<Json<LastBatchIndexesResponse>> {
+        INCOMING_REQUESTS.inc();
+
         // Return directly if cached.
         if let Some(response) =
             LastBatchIndexesResponse::from_cache(&state.cache, "last_batch_indexes").await
@@ -262,6 +274,8 @@ impl Apis {
         state: Data<&State>,
         keyword: Query<String>,
     ) -> Result<Json<SearchResponse>> {
+        INCOMING_REQUESTS.inc();
+
         let keyword = keyword.0;
 
         // Return directly if cached.

--- a/src/open_api/apis.rs
+++ b/src/open_api/apis.rs
@@ -1,11 +1,11 @@
 use crate::{
     consts::*,
     db::*,
-    open_api::{responses::*, State, INCOMING_REQUESTS},
+    open_api::{responses::*, State, INCOMING_REQUESTS, RESPONSE_TIME_COLLECTOR},
 };
 use poem::{error::InternalServerError, web::Data, Result};
 use poem_openapi::{param::Query, payload::Json, OpenApi};
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 // Macro used to log error with right line number.
 macro_rules! api_err {
@@ -21,6 +21,7 @@ pub(crate) struct Apis;
 impl Apis {
     #[oai(path = "/batch", method = "get")]
     async fn batch(&self, state: Data<&State>, index: Query<i64>) -> Result<Json<BatchResponse>> {
+        let response_time = Instant::now();
         INCOMING_REQUESTS.inc();
 
         let index = index.0;
@@ -29,6 +30,11 @@ impl Apis {
         let cache_key = format!("batch-{index}");
         if let Some(response) = BatchResponse::from_cache(state.cache.as_ref(), &cache_key).await {
             log::debug!("OpenAPI - Get batch from Cache: {response:?}");
+
+            RESPONSE_TIME_COLLECTOR
+                .with_label_values(&["batch"])
+                .observe(response_time.elapsed().as_secs_f64());
+
             return Ok(Json(response));
         };
 
@@ -50,6 +56,10 @@ impl Apis {
             log::error!("OpenAPI - Failed to save cache of {cache_key}: {error}");
         }
 
+        RESPONSE_TIME_COLLECTOR
+            .with_label_values(&["batch"])
+            .observe(response_time.elapsed().as_secs_f64());
+
         Ok(Json(response))
     }
 
@@ -60,6 +70,7 @@ impl Apis {
         page: Query<Option<u64>>,
         per_page: Query<Option<u64>>,
     ) -> Result<Json<BatchesResponse>> {
+        let response_time = Instant::now();
         INCOMING_REQUESTS.inc();
 
         let limit = per_page.0.map_or_else(
@@ -85,6 +96,11 @@ impl Apis {
         if let Some(response) = BatchesResponse::from_cache(state.cache.as_ref(), &cache_key).await
         {
             log::debug!("OpenAPI - Get batches from Cache: {response:?}");
+
+            RESPONSE_TIME_COLLECTOR
+                .with_label_values(&["batches"])
+                .observe(response_time.elapsed().as_secs_f64());
+
             return Ok(Json(response));
         };
 
@@ -109,6 +125,10 @@ impl Apis {
             log::error!("OpenAPI - Failed to save cache of {cache_key}: {error}");
         }
 
+        RESPONSE_TIME_COLLECTOR
+            .with_label_values(&["batches"])
+            .observe(response_time.elapsed().as_secs_f64());
+
         Ok(Json(response))
     }
 
@@ -118,6 +138,7 @@ impl Apis {
         state: Data<&State>,
         batch_index: Query<i64>,
     ) -> Result<Json<BlocksResponse>> {
+        let response_time = Instant::now();
         INCOMING_REQUESTS.inc();
 
         let batch_index = batch_index.0;
@@ -126,6 +147,11 @@ impl Apis {
         let cache_key = format!("blocks-of-batch-{batch_index}");
         if let Some(response) = BlocksResponse::from_cache(state.cache.as_ref(), &cache_key).await {
             log::debug!("OpenAPI - Get blocks from Cache: {response:?}");
+
+            RESPONSE_TIME_COLLECTOR
+                .with_label_values(&["batch_blocks"])
+                .observe(response_time.elapsed().as_secs_f64());
+
             return Ok(Json(response));
         };
 
@@ -144,6 +170,10 @@ impl Apis {
             log::error!("OpenAPI - Failed to save cache of {cache_key}: {error}");
         }
 
+        RESPONSE_TIME_COLLECTOR
+            .with_label_values(&["batch_blocks"])
+            .observe(response_time.elapsed().as_secs_f64());
+
         Ok(Json(response))
     }
 
@@ -153,6 +183,7 @@ impl Apis {
         state: Data<&State>,
         batch_index: Query<i64>,
     ) -> Result<Json<ChunksResponse>> {
+        let response_time = Instant::now();
         INCOMING_REQUESTS.inc();
 
         let batch_index = batch_index.0;
@@ -161,6 +192,11 @@ impl Apis {
         let cache_key = format!("chunks-of-batch-{batch_index}");
         if let Some(response) = ChunksResponse::from_cache(state.cache.as_ref(), &cache_key).await {
             log::debug!("OpenAPI - Get chunks from Cache: {response:?}");
+
+            RESPONSE_TIME_COLLECTOR
+                .with_label_values(&["chunks"])
+                .observe(response_time.elapsed().as_secs_f64());
+
             return Ok(Json(response));
         };
 
@@ -192,6 +228,10 @@ impl Apis {
             log::error!("OpenAPI - Failed to save cache of {cache_key}: {error}");
         }
 
+        RESPONSE_TIME_COLLECTOR
+            .with_label_values(&["chunks"])
+            .observe(response_time.elapsed().as_secs_f64());
+
         Ok(Json(response))
     }
 
@@ -201,6 +241,7 @@ impl Apis {
         state: Data<&State>,
         chunk_index: Query<i64>,
     ) -> Result<Json<BlocksResponse>> {
+        let response_time = Instant::now();
         INCOMING_REQUESTS.inc();
 
         let chunk_index = chunk_index.0;
@@ -209,6 +250,11 @@ impl Apis {
         let cache_key = format!("blocks-of-chunk-{chunk_index}");
         if let Some(response) = BlocksResponse::from_cache(state.cache.as_ref(), &cache_key).await {
             log::debug!("OpenAPI - Get blocks from Cache: {response:?}");
+
+            RESPONSE_TIME_COLLECTOR
+                .with_label_values(&["chunk_blocks"])
+                .observe(response_time.elapsed().as_secs_f64());
+
             return Ok(Json(response));
         };
 
@@ -227,6 +273,10 @@ impl Apis {
             log::error!("OpenAPI - Failed to save cache of {cache_key}: {error}");
         }
 
+        RESPONSE_TIME_COLLECTOR
+            .with_label_values(&["chunk_blocks"])
+            .observe(response_time.elapsed().as_secs_f64());
+
         Ok(Json(response))
     }
 
@@ -235,6 +285,7 @@ impl Apis {
         &self,
         state: Data<&State>,
     ) -> Result<Json<LastBatchIndexesResponse>> {
+        let response_time = Instant::now();
         INCOMING_REQUESTS.inc();
 
         // Return directly if cached.
@@ -242,6 +293,11 @@ impl Apis {
             LastBatchIndexesResponse::from_cache(&state.cache, "last_batch_indexes").await
         {
             log::debug!("OpenAPI - Get last batch indexes from Cache: {response:?}");
+
+            RESPONSE_TIME_COLLECTOR
+                .with_label_values(&["last_batch_indexes"])
+                .observe(response_time.elapsed().as_secs_f64());
+
             return Ok(Json(response));
         };
 
@@ -263,6 +319,10 @@ impl Apis {
             log::error!("OpenAPI - Failed to save cache for last batch indexes: {error}");
         }
 
+        RESPONSE_TIME_COLLECTOR
+            .with_label_values(&["last_batch_indexes"])
+            .observe(response_time.elapsed().as_secs_f64());
+
         Ok(Json(response))
     }
 
@@ -274,6 +334,7 @@ impl Apis {
         state: Data<&State>,
         keyword: Query<String>,
     ) -> Result<Json<SearchResponse>> {
+        let response_time = Instant::now();
         INCOMING_REQUESTS.inc();
 
         let keyword = keyword.0;
@@ -282,6 +343,11 @@ impl Apis {
         let cache_key = format!("search-{keyword}");
         if let Some(response) = SearchResponse::from_cache(state.cache.as_ref(), &cache_key).await {
             log::debug!("OpenAPI - Get blocks from Cache: {response:?}");
+
+            RESPONSE_TIME_COLLECTOR
+                .with_label_values(&["search"])
+                .observe(response_time.elapsed().as_secs_f64());
+
             return Ok(Json(response));
         };
 
@@ -318,6 +384,10 @@ impl Apis {
         {
             log::error!("OpenAPI - Failed to save cache of {cache_key}: {error}");
         }
+
+        RESPONSE_TIME_COLLECTOR
+            .with_label_values(&["search"])
+            .observe(response_time.elapsed().as_secs_f64());
 
         Ok(Json(response))
     }


### PR DESCRIPTION
### Summary

- add `incoming_requests` and `response_time` metrics.

<img width="400" alt="Screen Shot 2023-09-22 at 11 06 08 AM" src="https://github.com/scroll-tech/rollup-explorer-backend/assets/31645658/fdaed494-ee76-4379-965a-5f1895e1b1cd">

- add `tokio_metrics`.

<img width="400" alt="Screen Shot 2023-09-22 at 11 06 31 AM" src="https://github.com/scroll-tech/rollup-explorer-backend/assets/31645658/ea483cf6-d5e1-4fa9-ab4e-b4b6eddbbcc1">

