### PR TITLE
feat: export `metrics` related paths to port `6001`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,6 +635,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,6 +688,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
 name = "futures-macro"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,10 +722,13 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1814,6 +1838,7 @@ dependencies = [
  "chrono",
  "config",
  "dotenvy",
+ "futures",
  "lazy_static",
  "log",
  "poem",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0"
 chrono = { version = "0.4", features = [ "serde" ] }
 config = "0.13"
 dotenvy = "0.15"
+futures = "0.3"
 lazy_static = "1.4"
 log = "0.4"
 poem = { version = "1.3", features = ["prometheus", "tokio-metrics"] }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use std::{env, sync::OnceLock};
 
 const DEFAULT_BIND_PORT: &str = "5001";
+const DEFAULT_METRICS_BIND_PORT: &str = "6001";
 const DEFAULT_MAX_CONNS: u32 = 200;
 
 static SETTINGS: OnceLock<Settings> = OnceLock::new();
@@ -13,6 +14,8 @@ static SETTINGS: OnceLock<Settings> = OnceLock::new();
 pub struct Settings {
     /// Internal HTTP bind port (5001 as default)
     pub bind_port: String,
+    /// Internal HTTP metrics bind port (6001 as default)
+    pub metrics_bind_port: String,
     /// As format of `postgres://USERNAME:PASSWORD@DB_HOST:DB_PORT/DATABASE`
     pub db_url: String,
     /// As format of `HTTP_HOST:HTTP_PORT`
@@ -30,6 +33,8 @@ pub struct Settings {
 impl Settings {
     pub fn init() -> Result<()> {
         let bind_port = env::var("BIND_PORT").unwrap_or_else(|_| DEFAULT_BIND_PORT.into());
+        let metrics_bind_port =
+            env::var("METRICS_BIND_PORT").unwrap_or_else(|_| DEFAULT_METRICS_BIND_PORT.into());
         let run_mode = env::var("RUN_MODE").unwrap_or_else(|_| "development".into());
         let max_db_conns = env::var("MAX_DB_CONNS").map_or_else(
             |_| DEFAULT_MAX_CONNS,
@@ -45,6 +50,7 @@ impl Settings {
         );
         let config = Config::builder()
             .set_default("bind_port", bind_port)?
+            .set_default("metrics_bind_port", metrics_bind_port)?
             .set_default("run_mode", run_mode.clone())?
             .set_default("max_per_page", 100)?
             .set_default("max_db_conns", max_db_conns)?


### PR DESCRIPTION
### Summary

Export `/metrics` and `/tokio_metrics` paths to port `6001`.

Tested on local as:

api:
<img width="400" alt="app" src="https://github.com/scroll-tech/rollup-explorer-backend/assets/31645658/83b55a61-6b74-4840-b98b-5987a2ac25d8">

metrics:
<img width="400" alt="metrics" src="https://github.com/scroll-tech/rollup-explorer-backend/assets/31645658/7c6cc463-9790-4160-912b-3d03b59848a6">

tokio_metrics:
<img width="400" alt="tokio_metrics" src="https://github.com/scroll-tech/rollup-explorer-backend/assets/31645658/9a53c073-43ee-483d-950b-7fbc86876995">


