### PR TITLE
ci: use rust-cache v2

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -29,7 +29,7 @@ jobs:
           override: true
           profile: minimal
           toolchain: nightly-2022-07-26
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       # - run: |
       #     cargo install cargo-audit
       #     cargo audit \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
           override: true
           profile: minimal
           toolchain: nightly-2022-07-26
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - run: |
           cargo build --release
           cargo fmt --all -- --check
@@ -45,5 +45,5 @@ jobs:
           override: true
           profile: minimal
           toolchain: nightly-2022-07-26
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - run: cargo clippy -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,6 @@ jobs:
           override: true
           profile: minimal
           toolchain: nightly-2022-07-26
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
       - run: cargo nextest run --all


### PR DESCRIPTION
This PR updates the GitHub actions to use the latest version of [Swatinem's rust-cache](https://github.com/Swatinem/rust-cache).

Related to https://github.com/scroll-tech/rollup-explorer-backend/issues/106